### PR TITLE
Add allowImplicitScrolling property

### DIFF
--- a/lib/src/swiper.dart
+++ b/lib/src/swiper.dart
@@ -125,6 +125,8 @@ class Swiper extends StatefulWidget {
 
   final PageIndicatorLayout indicatorLayout;
 
+  final bool allowImplicitScrolling;
+
   const Swiper({
     this.itemBuilder,
     this.indicatorLayout = PageIndicatorLayout.NONE,
@@ -161,6 +163,7 @@ class Swiper extends StatefulWidget {
     this.outer = false,
     this.scale,
     this.fade,
+    this.allowImplicitScrolling = false,
   })  : assert(
           itemBuilder != null || transformer != null,
           'itemBuilder and transformItemBuilder must not be both null',
@@ -517,6 +520,7 @@ class _SwiperState extends _SwiperTimerMixin {
         curve: widget.curve,
         physics: widget.physics,
         controller: _controller,
+        allowImplicitScrolling: widget.allowImplicitScrolling,
       );
       if (widget.autoplayDisableOnInteraction && widget.autoplay) {
         return NotificationListener(

--- a/lib/src/transformer_page_view/transformer_page_view.dart
+++ b/lib/src/transformer_page_view/transformer_page_view.dart
@@ -241,6 +241,8 @@ class TransformerPageView extends StatefulWidget {
   /// If not set, it is controlled by this widget.
   final int? index;
 
+  final bool allowImplicitScrolling;
+
   /// Creates a scrollable list that works page by page using widgets that are
   /// created on demand.
   ///
@@ -266,6 +268,7 @@ class TransformerPageView extends StatefulWidget {
     this.onPageChanged,
     this.controller,
     this.transformer,
+    this.allowImplicitScrolling = false,
     this.itemBuilder,
     this.pageController,
     required this.itemCount,
@@ -287,6 +290,7 @@ class TransformerPageView extends StatefulWidget {
     ValueChanged<int?>? onPageChanged,
     IndexController? controller,
     PageTransformer? transformer,
+    bool allowImplicitScrolling = false,
     required List<Widget> children,
     TransformerPageController? pageController,
   }) {
@@ -306,6 +310,7 @@ class TransformerPageView extends StatefulWidget {
       viewportFraction: viewportFraction,
       scrollDirection: scrollDirection,
       physics: physics,
+      allowImplicitScrolling: allowImplicitScrolling,
       onPageChanged: onPageChanged,
       controller: controller,
     );
@@ -418,6 +423,7 @@ class _TransformerPageViewState extends State<TransformerPageView> {
   Widget build(BuildContext context) {
     final builder = _transformer == null ? _buildItemNormal : _buildItem;
     final child = PageView.builder(
+      allowImplicitScrolling: widget.allowImplicitScrolling,
       itemBuilder: builder,
       itemCount: _pageController.getRealItemCount(),
       onPageChanged: _onIndexChanged,


### PR DESCRIPTION
This allows a widget to be preloaded before it is visible if this value is set a `true`. This is especially useful when using network image widgets.