### PR TITLE
hide items at the end of swiper if it's not looping

### DIFF
--- a/lib/src/custom_layout.dart
+++ b/lib/src/custom_layout.dart
@@ -101,8 +101,10 @@ abstract class _CustomLayoutStateBase<T extends _SubSwiper> extends State<T>
     final animationValue = _animation.value;
 
     for (var i = 0; i < _animationCount! && widget.itemCount > 0; ++i) {
-      var realIndex = _currentIndex + i + _startIndex;
-      realIndex = realIndex % widget.itemCount;
+      final itemIndex = _currentIndex + i + _startIndex;
+      if (!widget.loop && itemIndex >= widget.itemCount) continue;
+
+      var realIndex = itemIndex % widget.itemCount;
       if (realIndex < 0) {
         realIndex += widget.itemCount;
       }


### PR DESCRIPTION
In the STACK layout with the right direction, when it's a non-looping swiper, it still shows some items which indicate that the user can swipe, but in reality, it's the end of the swiper, and the user can't swipe.
This can be worst when there are only one or two pictures in swiper.

fixes: #55 

OLD - one picture non-looping: 
<img width="398" alt="image" src="https://user-images.githubusercontent.com/24422125/190605847-ed5911e6-b32b-4d9b-b583-5ea3b510dba3.png">


NEW - one picture non-looping:
<img width="397" alt="image" src="https://user-images.githubusercontent.com/24422125/190605959-fec0431e-2dc2-430c-b9b5-7b9adbce7ca0.png">


OLD - two pictures non-looping:
<img width="398" alt="image" src="https://user-images.githubusercontent.com/24422125/190606383-bb59a58a-7ad4-4a52-a948-c61f1c806e94.png">



NEW - two pictures non-looping:
<img width="398" alt="image" src="https://user-images.githubusercontent.com/24422125/190606064-01d0bc3e-8446-4508-aecc-bc639a5a824b.png">
