### PR TITLE
Suppress onIndexChanged during move animations

### DIFF
--- a/lib/src/swiper.dart
+++ b/lib/src/swiper.dart
@@ -472,6 +472,11 @@ class _SwiperState extends _SwiperTimerMixin {
     setState(() {
       _activeIndex = index;
     });
+
+    final event = _controller.event;
+    if ((event is MoveIndexControllerEvent) && (event.newIndex != index)) {
+      return;
+    }
     widget.onIndexChanged?.call(index);
   }
 


### PR DESCRIPTION
Fixed an issue where onIndexChanged was being fired on visual effects when SwiperController.move(index,animation::true) was called.

fix #78 