### PR TITLE
add needToResetTimer to IndexControllerEventBase

### DIFF
--- a/lib/src/swiper.dart
+++ b/lib/src/swiper.dart
@@ -347,6 +347,10 @@ abstract class _SwiperTimerMixin extends State<Swiper> {
       } else {
         _stopAutoplay();
       }
+    } else if (event is IndexControllerEventBase) {
+      if (event.needToResetTimer) {
+        _startAutoplay();
+      }
     }
   }
 
@@ -388,7 +392,10 @@ abstract class _SwiperTimerMixin extends State<Swiper> {
   }
 
   Future<void> _onTimer(Timer timer) async {
-    return _controller.next(animation: true);
+    return _controller.next(
+      animation: true,
+      needToResetTimer: false,
+    );
   }
 
   void _stopAutoplay() {

--- a/lib/src/swiper_controller.dart
+++ b/lib/src/swiper_controller.dart
@@ -5,7 +5,10 @@ class SwipeIndexControllerEvent extends IndexControllerEventBase {
   SwipeIndexControllerEvent({
     required this.pos,
     required bool animation,
-  }) : super(animation: animation);
+  }) : super(
+          animation: animation,
+          needToResetTimer: false,
+        );
   final double pos;
 }
 
@@ -13,7 +16,10 @@ class BuildIndexControllerEvent extends IndexControllerEventBase {
   BuildIndexControllerEvent({
     required bool animation,
     required this.config,
-  }) : super(animation: animation);
+  }) : super(
+          animation: animation,
+          needToResetTimer: false,
+        );
   final SwiperPluginConfig config;
 }
 
@@ -21,7 +27,10 @@ class AutoPlaySwiperControllerEvent extends IndexControllerEventBase {
   AutoPlaySwiperControllerEvent({
     required bool animation,
     required this.autoplay,
-  }) : super(animation: animation);
+  }) : super(
+          animation: animation,
+          needToResetTimer: false,
+        );
 
   AutoPlaySwiperControllerEvent.start({
     required bool animation,

--- a/lib/src/transformer_page_view/index_controller.dart
+++ b/lib/src/transformer_page_view/index_controller.dart
@@ -6,9 +6,11 @@ import 'package:flutter/widgets.dart';
 abstract class IndexControllerEventBase {
   IndexControllerEventBase({
     required this.animation,
+    required this.needToResetTimer,
   });
 
   final bool animation;
+  final bool needToResetTimer;
 
   final completer = Completer<void>();
   Future<void> get future => completer.future;
@@ -52,8 +54,10 @@ class NextIndexControllerEvent extends IndexControllerEventBase
     with TargetedPositionControllerEvent, StepBasedIndexControllerEvent {
   NextIndexControllerEvent({
     required bool animation,
+    bool needToResetTimer = false,
   }) : super(
           animation: animation,
+          needToResetTimer: needToResetTimer,
         );
 
   @override
@@ -67,8 +71,10 @@ class PrevIndexControllerEvent extends IndexControllerEventBase
     with TargetedPositionControllerEvent, StepBasedIndexControllerEvent {
   PrevIndexControllerEvent({
     required bool animation,
+    bool needToResetTimer = false,
   }) : super(
           animation: animation,
+          needToResetTimer: needToResetTimer,
         );
   @override
   int get step => -1;
@@ -83,8 +89,10 @@ class MoveIndexControllerEvent extends IndexControllerEventBase
     required this.newIndex,
     required this.oldIndex,
     required bool animation,
+    bool needToResetTimer = false,
   }) : super(
           animation: animation,
+          needToResetTimer: needToResetTimer,
         );
   final int newIndex;
   final int oldIndex;
@@ -95,24 +103,41 @@ class MoveIndexControllerEvent extends IndexControllerEventBase
 class IndexController extends ChangeNotifier {
   IndexControllerEventBase? event;
   int index = 0;
-  Future<void> move(int index, {bool animation = true}) {
+  Future<void> move(
+    int index, {
+    bool animation = true,
+    bool needToResetTimer = true,
+  }) {
     final e = event = MoveIndexControllerEvent(
       animation: animation,
       newIndex: index,
       oldIndex: this.index,
+      needToResetTimer: needToResetTimer,
     );
     notifyListeners();
     return e.future;
   }
 
-  Future<void> next({bool animation = true}) {
-    final e = event = NextIndexControllerEvent(animation: animation);
+  Future<void> next({
+    bool animation = true,
+    bool needToResetTimer = true,
+  }) {
+    final e = event = NextIndexControllerEvent(
+      animation: animation,
+      needToResetTimer: needToResetTimer,
+    );
     notifyListeners();
     return e.future;
   }
 
-  Future<void> previous({bool animation = true}) {
-    final e = event = PrevIndexControllerEvent(animation: animation);
+  Future<void> previous({
+    bool animation = true,
+    bool needToResetTimer = true,
+  }) {
+    final e = event = PrevIndexControllerEvent(
+      animation: animation,
+      needToResetTimer: needToResetTimer,
+    );
     notifyListeners();
     return e.future;
   }


### PR DESCRIPTION
Usually, we hope Swiper delay when user trigger jump actively. So i add `needToResetTimer` to `IndexControllerEventBase`, in default, call `move()`/`next()`/`previous()` outside the package will reset timer to delay.